### PR TITLE
Fix output directory tree typo for initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ mkdir -p $TOOLS_DIR/bin
 Upon completing these commands, your directory tree should look like this:
 
 ``` sh
-├── bin
+├── build
 │   ├── bao
 │   ├── firmware
 │   └── guests


### PR DESCRIPTION
the `SETUP_BUILD` is set to `$ROOT_DIR/build` not `$ROOT_DIR/bin` in the README.md so output tree looks like this:

```
$ tree -d
.
├── bin
│   └── guests
│       ├── baremetal-freeRTOS-setup
│       ├── baremetal-linux-setup
│       ├── baremetal-linux-shmem-setup
│       └── baremetal-setup
├── build
│   ├── bao
│   ├── firmware
│   └── guests
├── configs
├── img
├── patches
├── srcs
│   ├── buildroot
│   ├── configs
│   ├── devicetrees
│   │   ├── qemu-aarch64-virt
│   │   └── qemu-riscv64-virt
│   ├── lloader
│   └── patches
│       ├── rel_imx_5.4.24_2.1.0
│       ├── v5.11
│       └── v6.1
└── tools
    └── bin
```